### PR TITLE
Fix tweet deletion from archive

### DIFF
--- a/main.go
+++ b/main.go
@@ -217,7 +217,7 @@ func unFavoriteTweet(api *anaconda.TwitterApi, t anaconda.Tweet) (bool, error) {
 
 func deleteFromData(api *anaconda.TwitterApi) error {
 	data := *archiveFolder
-	bts, err := os.ReadFile(filepath.Join(data.Name(), "data/tweet.js"))
+	bts, err := os.ReadFile(filepath.Join(data.Name(), "data/tweets.js"))
 	if err != nil {
 		return err
 	}
@@ -228,7 +228,7 @@ func deleteFromData(api *anaconda.TwitterApi) error {
 		} `json:"tweet"`
 	}
 
-	if err := json.Unmarshal(bytes.TrimPrefix(bts, []byte("window.YTD.tweet.part0 = ")), &tweets); err != nil {
+	if err := json.Unmarshal(bytes.TrimPrefix(bts, []byte("window.YTD.tweets.part0 = ")), &tweets); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
In current archives the file containing tweets is called `tweets.js` and its first line changed from `window.YTD.tweet.part0` to `window.YTD.tweets.part0`. These are all changes needed to make this script compatible with archive deletion again.

Fixes #51